### PR TITLE
CI typechecker configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ present in this repository. If a program needs some specific
 configuration options, e.g. enabling handlers, these can be set as
 follows:
 
-* For a single program (say "program.links"), create the file
-  "program.config" in the same directory that will contain the Links
+* For a single program (say `program.links`), create the file
+  `program.config` in the same directory that will contain the Links
   configuation to run that program.
 
 * For multiple programs in the same directory, you can also use a
-  default config: "_default.config" - this is the fallback if there
-  is no "program.config".
+  default config: `_default.config` - this is the fallback if there
+  is no `program.config`.
 
 * If none of these are present, Links will run with the default
   configuration.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ configuration options, e.g. enabling handlers, these can be set as
 follows:
 
 * For a single program (say "program.links"), create the file
-  "program.comfig" in the same directory that will contain the Links
+  "program.config" in the same directory that will contain the Links
   configuation to run that program.
 
 * For multiple programs in the same directory, you can also use a

--- a/README.md
+++ b/README.md
@@ -3,5 +3,24 @@
 This repository contains a collection of programs used to benchmark
 various components of Links.
 
+## Program configuration for CI
+
+The Continuous Integration automatically typechecks all Links programs
+present in this repository. If a program needs some specific
+configuration options, e.g. enabling handlers, these can be set as
+follows:
+
+* For a single program (say "program.links"), create the file
+  "program.comfig" in the same directory that will contain the Links
+  configuation to run that program.
+
+* For multiple programs in the same directory, you can also use a
+  default config: "_default.config" - this is the fallback if there
+  is no "program.config".
+
+* If none of these are present, Links will run with the default
+  configuration.
+
+
 -----
 [![Typecheck Links benchmark suite](https://github.com/links-lang/links-benchmarks/actions/workflows/default.yml/badge.svg?event=push)](https://github.com/links-lang/links-benchmarks/actions/workflows/default.yml)

--- a/typecheck
+++ b/typecheck
@@ -1,4 +1,19 @@
 #!/bin/bash
+
+# Configuration files:
+# ====================
+#
+# * For a single program (say "program.links"), create the file
+#   "program.comfig" in the same directory that will contain the Links
+#   configuation to run that program.
+#
+# * For multiple programs in the same directory, you can also use a
+#   default config: "_default.config" - this is the fallback if there
+#   is no "program.config".
+#
+# * If none of these are present, Links will run with the default
+#   configuration.
+
 FAILURES=0
 for p in $(find -P . -path ./_opam -prune -false -o -name "*.links"); do
   printf "%s..." $p
@@ -9,8 +24,7 @@ for p in $(find -P . -path ./_opam -prune -false -o -name "*.links"); do
     dirname=$(dirname "$p")
     basename=$(basename "$p")
     filename=${basename%.*}
-    echo $dirname
-    echo $filename
+    # Find an applicable config file if it exists
     if [[ -f "$dirname/$filename.config" ]]; then
       config="$dirname/$filename.config"
     elif [[ -f "$dirname/_default.config" ]]; then
@@ -18,9 +32,9 @@ for p in $(find -P . -path ./_opam -prune -false -o -name "*.links"); do
     else
       config=""
     fi
-    echo $config
+    # Run Links, possibly with the config
     if [[ -n $config ]]; then
-      linx --set=typecheck_only=true --set=config=$config $p
+      linx --set=typecheck_only=true --config=$config $p
     else
       linx --set=typecheck_only=true $p
     fi

--- a/typecheck
+++ b/typecheck
@@ -4,7 +4,7 @@
 # ====================
 #
 # * For a single program (say "program.links"), create the file
-#   "program.comfig" in the same directory that will contain the Links
+#   "program.config" in the same directory that will contain the Links
 #   configuation to run that program.
 #
 # * For multiple programs in the same directory, you can also use a

--- a/typecheck
+++ b/typecheck
@@ -34,7 +34,7 @@ for p in $(find -P . -path ./_opam -prune -false -o -name "*.links"); do
     fi
     # Run Links, possibly with the config
     if [[ -n $config ]]; then
-      linx --set=typecheck_only=true --config=$config $p
+      linx --config=$config --set=typecheck_only=true  $p
     else
       linx --set=typecheck_only=true $p
     fi

--- a/typecheck
+++ b/typecheck
@@ -6,7 +6,24 @@ for p in $(find -P . -path ./_opam -prune -false -o -name "*.links"); do
   if [[ $? -eq 0 ]]; then
     printf " IGNORED\n"
   else
-    linx --set=typecheck_only=true $p
+    dirname=$(dirname "$p")
+    basename=$(basename "$p")
+    filename=${basename%.*}
+    echo $dirname
+    echo $filename
+    if [[ -f "$dirname/$filename.config" ]]; then
+      config="$dirname/$filename.config"
+    elif [[ -f "$dirname/_default.config" ]]; then
+      config="$dirname/_default.config"
+    else
+      config=""
+    fi
+    echo $config
+    if [[ -n $config ]]; then
+      linx --set=typecheck_only=true --set=config=$config $p
+    else
+      linx --set=typecheck_only=true $p
+    fi
     if [[ $? -eq 0 ]]; then
       printf " SUCCESS\n"
     else


### PR DESCRIPTION
This PR extends the typecheck script to allow setting run configurations for individual Links programs or whole directories.

The script will check for `<program_name>.config`, and failing that for `_default.config` in the directory where `<program_name>.links` is located. Otherwise, Links will run with the default config (other than `typecheck_only`, this will always be true).